### PR TITLE
add support for blob tx

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -206,8 +206,8 @@ func ExecutableDataToBlock(params ExecutableData, versionedHashes []common.Hash,
 	for _, tx := range txs {
 		blobHashes = append(blobHashes, tx.BlobHashes()...)
 	}
-	// we only want to check versionedHashes when it's not nil
-	if versionedHashes == nil {
+	// we only want to check versionedHashes when it's not empty
+	if len(versionedHashes) == 0 {
 		versionedHashes = blobHashes
 	}
 	if len(blobHashes) != len(versionedHashes) {

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -206,6 +206,10 @@ func ExecutableDataToBlock(params ExecutableData, versionedHashes []common.Hash,
 	for _, tx := range txs {
 		blobHashes = append(blobHashes, tx.BlobHashes()...)
 	}
+	// we only want to check versionedHashes when it's not nil
+	if versionedHashes == nil {
+		versionedHashes = blobHashes
+	}
 	if len(blobHashes) != len(versionedHashes) {
 		return nil, fmt.Errorf("invalid number of versionedHashes: %v blobHashes: %v", versionedHashes, blobHashes)
 	}

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -194,7 +194,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		cfg.Eth.OverrideVerkle = &v
 	}
 
-	cfg.Eth.Enable4844ForOptimism = ctx.Bool(utils.Enable4844.Name)
+	cfg.Eth.EnableL2Blob = ctx.Bool(utils.EnableL2Blob.Name)
 
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -194,6 +194,8 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		cfg.Eth.OverrideVerkle = &v
 	}
 
+	cfg.Eth.Enable4844ForOptimism = ctx.Bool(utils.Enable4844.Name)
+
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 
 	// Create gauge with geth system and build information

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -70,6 +70,7 @@ var (
 		utils.OverrideOptimismCanyon,
 		utils.OverrideOptimismEcotone,
 		utils.OverrideOptimismInterop,
+		utils.EnableL2Blob,
 		utils.EnablePersonal,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -276,6 +276,11 @@ var (
 		Usage:    "Manually specify the Optimsim Interop feature-set fork timestamp, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
+	Enable4844 = &cli.BoolFlag{
+		Name:     "enable4844",
+		Usage:    "Manually enable 4844 for optimism",
+		Category: flags.EthCategory,
+	}
 	SyncModeFlag = &flags.TextMarshalerFlag{
 		Name:     "syncmode",
 		Usage:    `Blockchain sync mode ("snap" or "full")`,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -276,9 +276,9 @@ var (
 		Usage:    "Manually specify the Optimsim Interop feature-set fork timestamp, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
-	Enable4844 = &cli.BoolFlag{
-		Name:     "enable4844",
-		Usage:    "Manually enable 4844 for optimism",
+	EnableL2Blob = &cli.BoolFlag{
+		Name:     "enablel2blob",
+		Usage:    "Manually enable l2 blob for optimism",
 		Category: flags.EthCategory,
 	}
 	SyncModeFlag = &flags.TextMarshalerFlag{

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -271,7 +271,7 @@ type ChainOverrides struct {
 	OverrideOptimismCanyon  *uint64
 	OverrideOptimismEcotone *uint64
 	ApplySuperchainUpgrades bool
-	Enable4844ForOptimism   bool
+	EnableL2Blob            bool
 	OverrideOptimismInterop *uint64
 }
 
@@ -312,7 +312,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 			}
 
 			if config.IsOptimism() && overrides != nil {
-				config.Optimism.Enable4844 = overrides.Enable4844ForOptimism
+				config.Optimism.EnableL2Blob = overrides.EnableL2Blob
 			}
 			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(big.NewInt(params.OPGoerliChainID)) == 0 {
 				// Apply Optimism Goerli regolith time

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -311,7 +311,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 				}
 			}
 
-			if config.IsOptimism() && overrides.Enable4844ForOptimism {
+			if config.IsOptimism() && overrides != nil {
 				config.Optimism.Enable4844 = overrides.Enable4844ForOptimism
 			}
 			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(big.NewInt(params.OPGoerliChainID)) == 0 {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -271,6 +271,7 @@ type ChainOverrides struct {
 	OverrideOptimismCanyon  *uint64
 	OverrideOptimismEcotone *uint64
 	ApplySuperchainUpgrades bool
+	Enable4844ForOptimism   bool
 	OverrideOptimismInterop *uint64
 }
 
@@ -310,6 +311,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 				}
 			}
 
+			if config.IsOptimism() && overrides.Enable4844ForOptimism {
+				config.Optimism.Enable4844 = overrides.Enable4844ForOptimism
+			}
 			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(big.NewInt(params.OPGoerliChainID)) == 0 {
 				// Apply Optimism Goerli regolith time
 				config.RegolithTime = &params.OptimismGoerliRegolithTime

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -69,7 +69,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	if tx.Type() == types.DepositTxType {
 		return core.ErrTxTypeNotSupported
 	}
-	if opts.Config.IsOptimism() && !opts.Config.Optimism.Enable4844 && tx.Type() == types.BlobTxType {
+	if opts.Config.IsOptimism() && !opts.Config.Optimism.EnableL2Blob && tx.Type() == types.BlobTxType {
 		return core.ErrTxTypeNotSupported
 	}
 	// Ensure transactions not implemented by the calling pool are rejected

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -69,7 +69,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	if tx.Type() == types.DepositTxType {
 		return core.ErrTxTypeNotSupported
 	}
-	if opts.Config.IsOptimism() && tx.Type() == types.BlobTxType {
+	if false && opts.Config.IsOptimism() && tx.Type() == types.BlobTxType {
 		return core.ErrTxTypeNotSupported
 	}
 	// Ensure transactions not implemented by the calling pool are rejected

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -69,7 +69,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	if tx.Type() == types.DepositTxType {
 		return core.ErrTxTypeNotSupported
 	}
-	if false && opts.Config.IsOptimism() && tx.Type() == types.BlobTxType {
+	if opts.Config.IsOptimism() && !opts.Config.Optimism.Enable4844 && tx.Type() == types.BlobTxType {
 		return core.ErrTxTypeNotSupported
 	}
 	// Ensure transactions not implemented by the calling pool are rejected

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -79,7 +79,7 @@ var (
 // RollupCostData is a transaction structure that caches data for quickly computing the data
 // availablility costs for the transaction.
 type RollupCostData struct {
-	zeroes, ones uint64
+	zeroes, ones, blobs uint64
 }
 
 type StateGetter interface {
@@ -94,7 +94,7 @@ type L1CostFunc func(rcd RollupCostData, blockTime uint64) *big.Int
 // receipts.
 type l1CostFunc func(rcd RollupCostData) (fee, gasUsed *big.Int)
 
-func NewRollupCostData(data []byte) (out RollupCostData) {
+func NewRollupCostData(data []byte, blobs int) (out RollupCostData) {
 	for _, b := range data {
 		if b == 0 {
 			out.zeroes++
@@ -102,6 +102,7 @@ func NewRollupCostData(data []byte) (out RollupCostData) {
 			out.ones++
 		}
 	}
+	out.blobs = uint64(blobs)
 	return out
 }
 
@@ -189,7 +190,7 @@ func newL1CostFuncBedrockHelper(l1BaseFee, overhead, scalar *big.Int, isRegolith
 // very first block of the upgrade.
 func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFeeScalar *big.Int) l1CostFunc {
 	return func(costData RollupCostData) (fee, calldataGasUsed *big.Int) {
-		calldataGas := (costData.zeroes * params.TxDataZeroGas) + (costData.ones * params.TxDataNonZeroGasEIP2028)
+		calldataGas := (costData.zeroes * params.TxDataZeroGas) + (costData.ones * params.TxDataNonZeroGasEIP2028) + costData.blobs*params.BlobDAProofGas
 		calldataGasUsed = new(big.Int).SetUint64(calldataGas)
 
 		// Ecotone L1 cost function:
@@ -213,6 +214,7 @@ func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseF
 		fee = new(big.Int).Add(calldataCostPerByte, blobCostPerByte)
 		fee = fee.Mul(fee, calldataGasUsed)
 		fee = fee.Div(fee, ecotoneDivisor)
+		fee = fee.Add(fee, big.NewInt(int64(costData.blobs*params.BlobDAFee)))
 
 		return fee, calldataGasUsed
 	}

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -214,7 +214,7 @@ func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseF
 		fee = new(big.Int).Add(calldataCostPerByte, blobCostPerByte)
 		fee = fee.Mul(fee, calldataGasUsed)
 		fee = fee.Div(fee, ecotoneDivisor)
-		fee = fee.Add(fee, big.NewInt(int64(costData.blobs*params.BlobDAFee)))
+		fee = fee.Add(fee, new(big.Int).Mul(big.NewInt(int64(costData.blobs)), big.NewInt(params.BlobDAFee)))
 
 		return fee, calldataGasUsed
 	}

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -190,7 +190,7 @@ func newL1CostFuncBedrockHelper(l1BaseFee, overhead, scalar *big.Int, isRegolith
 // very first block of the upgrade.
 func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFeeScalar *big.Int) l1CostFunc {
 	return func(costData RollupCostData) (fee, calldataGasUsed *big.Int) {
-		calldataGas := (costData.zeroes * params.TxDataZeroGas) + (costData.ones * params.TxDataNonZeroGasEIP2028) + costData.blobs*params.BlobDAProofGas
+		calldataGas := (costData.zeroes * params.TxDataZeroGas) + (costData.ones * params.TxDataNonZeroGasEIP2028)
 		calldataGasUsed = new(big.Int).SetUint64(calldataGas)
 
 		// Ecotone L1 cost function:

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -378,11 +378,14 @@ func (tx *Transaction) RollupCostData() RollupCostData {
 	if v := tx.rollupCostData.Load(); v != nil {
 		return v.(RollupCostData)
 	}
+	// When called from commitBlobTransaction, tx contains blob.
+	// When called from state processor, tx doesn't contain blob.
+	// In order to make the result consistent, we should use the version without blob.
 	data, err := tx.WithoutBlobTxSidecar().MarshalBinary()
 	if err != nil { // Silent error, invalid txs will not be marshalled/unmarshalled for batch submission anyway.
 		log.Error("failed to encode tx for L1 cost computation", "err", err)
 	}
-	out := NewRollupCostData(data)
+	out := NewRollupCostData(data, len(tx.BlobHashes()))
 	tx.rollupCostData.Store(out)
 	return out
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -378,7 +378,7 @@ func (tx *Transaction) RollupCostData() RollupCostData {
 	if v := tx.rollupCostData.Load(); v != nil {
 		return v.(RollupCostData)
 	}
-	data, err := tx.MarshalBinary()
+	data, err := tx.WithoutBlobTxSidecar().MarshalBinary()
 	if err != nil { // Silent error, invalid txs will not be marshalled/unmarshalled for batch submission anyway.
 		log.Error("failed to encode tx for L1 cost computation", "err", err)
 	}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,7 +40,7 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64) Signer {
 	var signer Signer
 	switch {
-	case config.IsCancun(blockNumber, blockTime) && !config.IsOptimism():
+	case config.IsCancun(blockNumber, blockTime) && (true || !config.IsOptimism()):
 		signer = NewCancunSigner(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
@@ -65,7 +65,7 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
 	if config.ChainID != nil {
-		if config.CancunTime != nil && !config.IsOptimism() {
+		if config.CancunTime != nil && (true || !config.IsOptimism()) {
 			return NewCancunSigner(config.ChainID)
 		}
 		if config.LondonBlock != nil {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,7 +40,7 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64) Signer {
 	var signer Signer
 	switch {
-	case config.IsCancun(blockNumber, blockTime) && (true || !config.IsOptimism()):
+	case config.IsCancun(blockNumber, blockTime) && (!config.IsOptimism() || config.Optimism.Enable4844):
 		signer = NewCancunSigner(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
@@ -65,7 +65,7 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
 	if config.ChainID != nil {
-		if config.CancunTime != nil && (true || !config.IsOptimism()) {
+		if config.CancunTime != nil && (!config.IsOptimism() || config.Optimism.Enable4844) {
 			return NewCancunSigner(config.ChainID)
 		}
 		if config.LondonBlock != nil {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,7 +40,7 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64) Signer {
 	var signer Signer
 	switch {
-	case config.IsCancun(blockNumber, blockTime) && (!config.IsOptimism() || config.Optimism.Enable4844):
+	case config.IsCancun(blockNumber, blockTime) && (!config.IsOptimism() || config.Optimism.EnableL2Blob):
 		signer = NewCancunSigner(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
@@ -65,7 +65,7 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
 	if config.ChainID != nil {
-		if config.CancunTime != nil && (!config.IsOptimism() || config.Optimism.Enable4844) {
+		if config.CancunTime != nil && (!config.IsOptimism() || config.Optimism.EnableL2Blob) {
 			return NewCancunSigner(config.ChainID)
 		}
 		if config.LondonBlock != nil {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -293,7 +293,7 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
-	if false && b.ChainConfig().IsOptimism() && signedTx.Type() == types.BlobTxType {
+	if b.ChainConfig().IsOptimism() && !b.ChainConfig().Optimism.Enable4844 && signedTx.Type() == types.BlobTxType {
 		return types.ErrTxTypeNotSupported
 	}
 	if b.eth.seqRPCService != nil {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -293,7 +293,7 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
-	if b.ChainConfig().IsOptimism() && !b.ChainConfig().Optimism.Enable4844 && signedTx.Type() == types.BlobTxType {
+	if b.ChainConfig().IsOptimism() && !b.ChainConfig().Optimism.EnableL2Blob && signedTx.Type() == types.BlobTxType {
 		return types.ErrTxTypeNotSupported
 	}
 	if b.eth.seqRPCService != nil {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -293,7 +293,7 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
-	if b.ChainConfig().IsOptimism() && signedTx.Type() == types.BlobTxType {
+	if false && b.ChainConfig().IsOptimism() && signedTx.Type() == types.BlobTxType {
 		return types.ErrTxTypeNotSupported
 	}
 	if b.eth.seqRPCService != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -256,7 +256,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	legacyPool := legacypool.New(config.TxPool, eth.blockchain)
 
 	txPools := []txpool.SubPool{legacyPool}
-	if !eth.BlockChain().Config().IsOptimism() {
+	if true || !eth.BlockChain().Config().IsOptimism() {
 		blobPool := blobpool.New(config.BlobPool, eth.blockchain)
 		txPools = append(txPools, blobPool)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -230,7 +230,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		overrides.OverrideOptimismInterop = config.OverrideOptimismInterop
 	}
 	overrides.ApplySuperchainUpgrades = config.ApplySuperchainUpgrades
-	overrides.Enable4844ForOptimism = config.Enable4844ForOptimism
+	overrides.EnableL2Blob = config.EnableL2Blob
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TransactionHistory)
 	if err != nil {
 		return nil, err
@@ -257,7 +257,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	legacyPool := legacypool.New(config.TxPool, eth.blockchain)
 
 	txPools := []txpool.SubPool{legacyPool}
-	if !eth.BlockChain().Config().IsOptimism() || eth.BlockChain().Config().Optimism.Enable4844 {
+	if !eth.BlockChain().Config().IsOptimism() || eth.BlockChain().Config().Optimism.EnableL2Blob {
 		blobPool := blobpool.New(config.BlobPool, eth.blockchain)
 		txPools = append(txPools, blobPool)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -230,6 +230,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		overrides.OverrideOptimismInterop = config.OverrideOptimismInterop
 	}
 	overrides.ApplySuperchainUpgrades = config.ApplySuperchainUpgrades
+	overrides.Enable4844ForOptimism = config.Enable4844ForOptimism
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TransactionHistory)
 	if err != nil {
 		return nil, err
@@ -256,7 +257,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	legacyPool := legacypool.New(config.TxPool, eth.blockchain)
 
 	txPools := []txpool.SubPool{legacyPool}
-	if true || !eth.BlockChain().Config().IsOptimism() {
+	if !eth.BlockChain().Config().IsOptimism() || eth.BlockChain().Config().Optimism.Enable4844 {
 		blobPool := blobpool.New(config.BlobPool, eth.blockchain)
 		txPools = append(txPools, blobPool)
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -167,6 +167,7 @@ type Config struct {
 
 	OverrideOptimismInterop *uint64 `toml:",omitempty"`
 
+	// Enable accepting EIP-4844 BLOBs on L2
 	EnableL2Blob bool
 
 	// ApplySuperchainUpgrades requests the node to load chain-configuration from the superchain-registry.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -167,7 +167,7 @@ type Config struct {
 
 	OverrideOptimismInterop *uint64 `toml:",omitempty"`
 
-	Enable4844ForOptimism bool
+	EnableL2Blob bool
 
 	// ApplySuperchainUpgrades requests the node to load chain-configuration from the superchain-registry.
 	ApplySuperchainUpgrades bool `toml:",omitempty"`

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -167,6 +167,8 @@ type Config struct {
 
 	OverrideOptimismInterop *uint64 `toml:",omitempty"`
 
+	Enable4844ForOptimism bool
+
 	// ApplySuperchainUpgrades requests the node to load chain-configuration from the superchain-registry.
 	ApplySuperchainUpgrades bool `toml:",omitempty"`
 

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -664,6 +664,15 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.GasTipCap != nil {
 		arg["maxPriorityFeePerGas"] = (*hexutil.Big)(msg.GasTipCap)
 	}
+	if msg.AccessList != nil {
+		arg["accessList"] = msg.AccessList
+	}
+	if msg.BlobGasFeeCap != nil {
+		arg["maxFeePerBlobGas"] = (*hexutil.Big)(msg.BlobGasFeeCap)
+	}
+	if msg.BlobHashes != nil {
+		arg["blobVersionedHashes"] = msg.BlobHashes
+	}
 	return arg
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -140,6 +140,10 @@ type CallMsg struct {
 	Data      []byte          // input data, usually an ABI-encoded contract method invocation
 
 	AccessList types.AccessList // EIP-2930 access list.
+
+	// For BlobTxType
+	BlobGasFeeCap *big.Int
+	BlobHashes    []common.Hash
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -121,6 +121,8 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 			Value:                args.Value,
 			Data:                 (*hexutil.Bytes)(&data),
 			AccessList:           args.AccessList,
+			BlobFeeCap:           args.BlobFeeCap,
+			BlobHashes:           args.BlobHashes,
 		}
 		latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, b.RPCGasCap())

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -97,6 +97,13 @@ type environment struct {
 	receipts []*types.Receipt
 	sidecars []*types.BlobTxSidecar
 	blobs    int
+	noTxs    bool // this is used as a flag whether it's *effectively* sequencing or deriving
+}
+
+// isEffectivelySequencing is true when PayloadAttributes.NoTxPool is false,
+// which only happens when it's sequencing.
+func (env *environment) isEffectivelySequencing() bool {
+	return !env.noTxs
 }
 
 // copy creates a deep copy of environment.
@@ -798,14 +805,14 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction) ([]*
 
 func (w *worker) commitBlobTransaction(env *environment, tx *types.Transaction) ([]*types.Log, error) {
 	sc := tx.BlobTxSidecar()
-	if sc == nil {
+	if sc == nil && env.isEffectivelySequencing() /* we want to allow blob tx without blobs when it's deriving */ {
 		panic("blob transaction without blobs in miner")
 	}
 	// Checking against blob gas limit: It's kind of ugly to perform this check here, but there
 	// isn't really a better place right now. The blob gas limit is checked at block validation time
 	// and not during execution. This means core.ApplyTransaction will not return an error if the
 	// tx has too many blobs. So we have to explicitly check it here.
-	if (env.blobs+len(sc.Blobs))*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
+	if (env.blobs+len(tx.BlobHashes()))*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
 		return nil, errors.New("max data blobs reached")
 	}
 	receipt, err := w.applyTransaction(env, tx)
@@ -814,8 +821,10 @@ func (w *worker) commitBlobTransaction(env *environment, tx *types.Transaction) 
 	}
 	env.txs = append(env.txs, tx.WithoutBlobTxSidecar())
 	env.receipts = append(env.receipts, receipt)
-	env.sidecars = append(env.sidecars, sc)
-	env.blobs += len(sc.Blobs)
+	if sc != nil {
+		env.sidecars = append(env.sidecars, sc)
+	}
+	env.blobs += len(tx.BlobHashes())
 	*env.header.BlobGasUsed += receipt.BlobGasUsed
 	return receipt.Logs, nil
 }
@@ -1063,6 +1072,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		vmenv := vm.NewEVM(context, vm.TxContext{}, env.state, w.chainConfig, vm.Config{})
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, vmenv, env.state)
 	}
+	env.noTxs = genParams.noTxs // invariant: genParams.noTxs has the same boolean value as PayloadAttributes.NoTxPool
 	return env, nil
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -403,6 +403,7 @@ type OptimismConfig struct {
 	EIP1559Elasticity        uint64 `json:"eip1559Elasticity"`
 	EIP1559Denominator       uint64 `json:"eip1559Denominator"`
 	EIP1559DenominatorCanyon uint64 `json:"eip1559DenominatorCanyon"`
+	Enable4844               bool   `json:"enable4844"`
 }
 
 // String implements the stringer interface, returning the optimism fee config details.

--- a/params/config.go
+++ b/params/config.go
@@ -403,7 +403,7 @@ type OptimismConfig struct {
 	EIP1559Elasticity        uint64 `json:"eip1559Elasticity"`
 	EIP1559Denominator       uint64 `json:"eip1559Denominator"`
 	EIP1559DenominatorCanyon uint64 `json:"eip1559DenominatorCanyon"`
-	Enable4844               bool   `json:"enable4844"`
+	EnableL2Blob             bool   `json:"enable4844"`
 }
 
 // String implements the stringer interface, returning the optimism fee config details.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -48,7 +48,7 @@ const (
 	CallStipend           uint64 = 2300  // Free gas given at beginning of call.
 
 	BlobDAFee      = 2000 // Fee for storing blob to DA provider
-	BlobDAProofGas = 200  // Gas for storing DA proof to span batch
+	BlobDAProofGas = 200  // Gas for storing DA proof to span batch, it should be average proof size * TxDataNonZeroGasEIP2028
 
 	Keccak256Gas     uint64 = 30 // Once per KECCAK256 operation.
 	Keccak256WordGas uint64 = 6  // Once per word of the KECCAK256 operation's data.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -47,6 +47,9 @@ const (
 	LogDataGas            uint64 = 8     // Per byte in a LOG* operation's data.
 	CallStipend           uint64 = 2300  // Free gas given at beginning of call.
 
+	BlobDAFee      = 2000
+	BlobDAProofGas = 200
+
 	Keccak256Gas     uint64 = 30 // Once per KECCAK256 operation.
 	Keccak256WordGas uint64 = 6  // Once per word of the KECCAK256 operation's data.
 	InitCodeWordGas  uint64 = 2  // Once per word of the init code when creating a contract.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -47,8 +47,8 @@ const (
 	LogDataGas            uint64 = 8     // Per byte in a LOG* operation's data.
 	CallStipend           uint64 = 2300  // Free gas given at beginning of call.
 
-	BlobDAFee      = 2000
-	BlobDAProofGas = 200
+	BlobDAFee      = 2000 // Fee for storing blob to DA provider
+	BlobDAProofGas = 200  // Gas for storing DA proof to span batch
 
 	Keccak256Gas     uint64 = 30 // Once per KECCAK256 operation.
 	Keccak256WordGas uint64 = 6  // Once per word of the KECCAK256 operation's data.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -47,8 +47,7 @@ const (
 	LogDataGas            uint64 = 8     // Per byte in a LOG* operation's data.
 	CallStipend           uint64 = 2300  // Free gas given at beginning of call.
 
-	BlobDAFee      = 2000 // Fee for storing blob to DA provider
-	BlobDAProofGas = 200  // Gas for storing DA proof to span batch, it should be average proof size * TxDataNonZeroGasEIP2028
+	BlobDAFee = 2000 // Fee for storing blob to DA provider
 
 	Keccak256Gas     uint64 = 30 // Once per KECCAK256 operation.
 	Keccak256WordGas uint64 = 6  // Once per word of the KECCAK256 operation's data.


### PR DESCRIPTION
Summary of this PR:
1. allow l2 blob tx if `enablel2blob` is specified.
2. add blobs field to `RollupCostData`, and update `newL1CostFuncEcotone` accordingly, basically a blob tx will have two extra fees: da fee and da proof fee.
3. fix `Transaction.RollupCostData` so that the result is consistent when called from worker and state processor.
4. port changes from upstream geth to support estimate gas for blob tx.