### PR TITLE
fix gas balance validation issue when balance < gas cost < SGT balance

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -279,6 +279,33 @@ func (st *StateTransition) GetSoulBalance(account common.Address) *uint256.Int {
 	return balance
 }
 
+func GetEffectiveGasBalance(state vm.StateDB, chainconfig *params.ChainConfig, account common.Address) *uint256.Int {
+	bal, sgtBal := GetGasBalances(state, chainconfig, account)
+	if bal.Cmp(sgtBal) < 0 {
+		return sgtBal
+	}
+
+	return bal
+}
+
+func GetGasBalances(state vm.StateDB, chainconfig *params.ChainConfig, account common.Address) (*uint256.Int, *uint256.Int) {
+	balance := state.GetBalance(account)
+	if chainconfig != nil && chainconfig.IsOptimism() && chainconfig.Optimism.UseSoulGasToken {
+		sgtBalanceSlot := TargetSGTBalanceSlot(account)
+		sgtBalanceValue := state.GetState(types.SoulGasTokenAddr, sgtBalanceSlot)
+		sgtBalance := new(uint256.Int).SetBytes(sgtBalanceValue[:])
+
+		return balance, sgtBalance
+	}
+
+	return balance, uint256.NewInt(0)
+}
+
+func GetGasBalancesInBig(state vm.StateDB, chainconfig *params.ChainConfig, account common.Address) (*big.Int, *big.Int) {
+	bal, sgtBal := GetGasBalances(state, chainconfig, account)
+	return bal.ToBig(), sgtBal.ToBig()
+}
+
 func (st *StateTransition) SubSoulBalance(account common.Address, amount *big.Int, reason tracing.BalanceChangeReason) (err error) {
 	current := st.GetSoulBalance(account).ToBig()
 	if current.Cmp(amount) < 0 {

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -668,8 +668,9 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 	// Ensure that there's no over-draft, this is expected to happen when some
 	// transactions get included without publishing on the network
 	var (
-		balance = core.GetEffectiveGasBalance(p.state, p.chain.Config(), addr)
-		spent   = p.spent[addr]
+		balanceInBig, _ = core.GetEffectiveGasBalance(p.state, p.chain.Config(), addr, nil)
+		balance = uint256.MustFromBig(balanceInBig)
+		spent      = p.spent[addr]
 	)
 	if spent.Cmp(balance) > 0 {
 		// Evict the highest nonce transactions until the pending set falls under

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -667,11 +667,10 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 	}
 	// Ensure that there's no over-draft, this is expected to happen when some
 	// transactions get included without publishing on the network
-	var (
-		balanceInBig, _ = core.GetEffectiveGasBalance(p.state, p.chain.Config(), addr, nil)
-		balance = uint256.MustFromBig(balanceInBig)
-		spent      = p.spent[addr]
-	)
+	balance, sgtBalance := core.GetGasBalances(p.state, p.chain.Config(), addr)
+	// TODO: we may need a better filter such as tx.value < acc.balance
+	balance = balance.Add(balance, sgtBalance)
+	spent := p.spent[addr]
 	if spent.Cmp(balance) > 0 {
 		// Evict the highest nonce transactions until the pending set falls under
 		// the account's available balance

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -668,7 +668,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 	// Ensure that there's no over-draft, this is expected to happen when some
 	// transactions get included without publishing on the network
 	var (
-		balance = p.state.GetBalance(addr)
+		balance = core.GetEffectiveGasBalance(p.state, p.chain.Config(), addr)
 		spent   = p.spent[addr]
 	)
 	if spent.Cmp(balance) > 0 {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1520,7 +1520,9 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 			pool.all.Remove(hash)
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
-		balance := core.GetEffectiveGasBalance(pool.currentState, pool.chainconfig, addr)
+		balance, sgtBalance := core.GetGasBalances(pool.currentState, pool.chainconfig, addr)
+		// TODO: we may need a better filter such as tx.value < acc.balance
+		balance = balance.Add(balance, sgtBalance)
 		balance = pool.reduceBalanceByL1Cost(list, balance)
 		// Drop all transactions that are too costly (low balance or out of gas)
 		drops, _ := list.Filter(balance, gasLimit)
@@ -1723,7 +1725,9 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			pool.all.Remove(hash)
 			log.Trace("Removed old pending transaction", "hash", hash)
 		}
-		balance := core.GetEffectiveGasBalance(pool.currentState, pool.chainconfig, addr)
+		balance, sgtBalance := core.GetGasBalances(pool.currentState, pool.chainconfig, addr)
+		// TODO: we may need a better filter such as tx.value < acc.balance
+		balance = balance.Add(balance, sgtBalance)
 		balance = pool.reduceBalanceByL1Cost(list, balance)
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
 		drops, invalids := list.Filter(balance, gasLimit)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1520,7 +1520,7 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 			pool.all.Remove(hash)
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
-		balance := pool.currentState.GetBalance(addr)
+		balance := core.GetEffectiveGasBalance(pool.currentState, pool.chainconfig, addr)
 		balance = pool.reduceBalanceByL1Cost(list, balance)
 		// Drop all transactions that are too costly (low balance or out of gas)
 		drops, _ := list.Filter(balance, gasLimit)
@@ -1723,7 +1723,7 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			pool.all.Remove(hash)
 			log.Trace("Removed old pending transaction", "hash", hash)
 		}
-		balance := pool.currentState.GetBalance(addr)
+		balance := core.GetEffectiveGasBalance(pool.currentState, pool.chainconfig, addr)
 		balance = pool.reduceBalanceByL1Cost(list, balance)
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
 		drops, invalids := list.Filter(balance, gasLimit)

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/holiman/uint256"
 )
 
 // L1 Info Gas Overhead is the amount of gas the the L1 info deposit consumes.
@@ -254,16 +253,9 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 	}
 	// Ensure the transactor has enough funds to cover the transaction costs
 	var (
-		balance = opts.State.GetBalance(from).ToBig()
-		cost    = tx.Cost()
+		balance, sgtBalance = core.GetGasBalancesInBig(opts.State, opts.Chainconfig, from)
+		cost                = tx.Cost()
 	)
-
-	sgtBalance := new(big.Int)
-	if opts.Chainconfig != nil && opts.Chainconfig.IsOptimism() && opts.Chainconfig.Optimism.UseSoulGasToken {
-		sgtBalanceSlot := core.TargetSGTBalanceSlot(from)
-		sgtBalanceValue := opts.State.GetState(types.SoulGasTokenAddr, sgtBalanceSlot)
-		sgtBalance = new(uint256.Int).SetBytes(sgtBalanceValue[:]).ToBig()
-	}
 
 	if opts.L1CostFn != nil {
 		if l1Cost := opts.L1CostFn(tx.RollupCostData()); l1Cost != nil { // add rollup cost

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -382,6 +382,15 @@ func (tx *Transaction) Cost() *big.Int {
 	return total
 }
 
+// Cost returns (gas * gasPrice) + (blobGas * blobGasPrice).
+func (tx *Transaction) GasCost() *big.Int {
+	total := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.Gas()))
+	if tx.Type() == BlobTxType {
+		total.Add(total, new(big.Int).Mul(tx.BlobGasFeeCap(), new(big.Int).SetUint64(tx.BlobGas())))
+	}
+	return total
+}
+
 // RollupCostData caches the information needed to efficiently compute the data availability fee
 func (tx *Transaction) RollupCostData() RollupCostData {
 	if tx.Type() == DepositTxType {

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -71,7 +71,7 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 	}
 	// Recap the highest gas limit with account's available balance.
 	if feeCap.BitLen() != 0 {
-		balance := opts.State.GetBalance(call.From).ToBig()
+		balance := core.GetEffectiveGasBalance(opts.State, opts.Config, call.From).ToBig()
 
 		available := balance
 		if call.Value != nil {

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -71,15 +71,12 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 	}
 	// Recap the highest gas limit with account's available balance.
 	if feeCap.BitLen() != 0 {
-		balance := core.GetEffectiveGasBalance(opts.State, opts.Config, call.From).ToBig()
+		balance, err := core.GetEffectiveGasBalance(opts.State, opts.Config, call.From, call.Value)
+		if err != nil {
+			return 0, nil, err
+		}
 
 		available := balance
-		if call.Value != nil {
-			if call.Value.Cmp(available) >= 0 {
-				return 0, nil, core.ErrInsufficientFundsForTransfer
-			}
-			available.Sub(available, call.Value)
-		}
 		if opts.Config.IsCancun(opts.Header.Number, opts.Header.Time) && len(call.BlobHashes) > 0 {
 			blobGasPerBlob := new(big.Int).SetInt64(params.BlobTxBlobGasPerBlob)
 			blobBalanceUsage := new(big.Int).SetInt64(int64(len(call.BlobHashes)))

--- a/params/config.go
+++ b/params/config.go
@@ -523,6 +523,13 @@ func (c *ChainConfig) Description() string {
 	if c.InteropTime != nil {
 		banner += fmt.Sprintf(" - Interop:                     @%-10v\n", *c.InteropTime)
 	}
+	if c.L2BlobTime != nil {
+		banner += fmt.Sprintf(" - L2BLob:                     @%-10v\n", *c.L2BlobTime)
+	}
+	banner += "\n"
+	if c.Optimism != nil {
+		banner += fmt.Sprintf("SGT: %t, Back by native %t", c.Optimism.UseSoulGasToken, c.Optimism.IsSoulBackedByNative)
+	}
 	return banner
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The fix aims to address the validation issue during the tx submission when balance < gas cost < SGT balance (see https://github.com/ethstorage/op-geth/issues/11), including
- introduce new methods to get balances (native/SGT) and effective gas balance
- both txpool and gas estimator will use the effective gas balance to validate a tx

**Tests**

Run a devnet, and be able to
- submit a tx with zero balance and sufficient SGT balance.
- submit a zero-value tx with a non-zero-balance account and sufficient SGT balance. I checked that the balance is unchanged and the SGT balance is reduced.
- submit an all-value tx with a non-zero-balance account and sufficient SGT balance. I checked that the balance is zero and the SGT balance is reduced.


