### PR TITLE
Partial SGT

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -275,7 +275,11 @@ func (st *StateTransition) collectableNativeBalance(amount *uint256.Int) *uint25
 
 // distributeGas distributes the gas according to the priority:
 //
-//	first pool1, then pool2
+//		first pool1, then pool2.
+//
+//	 In more detail:
+//		split amount among two pools, first pool1, then pool2, where poolx means max amount for pool x.
+//		quotax is the amount distributed to pool x.
 //
 // note: the returned values are always non-nil.
 func (st *StateTransition) distributeGas(amount, pool1, pool2 *uint256.Int) (quota1, quota2 *uint256.Int) {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -834,13 +834,19 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 
 			if shouldCheckGasFormula {
 				st.l1Fee = amtU256.Clone()
-				if err := st.checkGasFormula(); err != nil {
-					return nil, err
-				}
 			}
 
 			amtU256 = st.collectableNativeBalance(amtU256)
 			st.state.AddBalance(params.OptimismL1FeeRecipient, amtU256, tracing.BalanceIncreaseRewardTransactionFee)
+		}
+
+		if shouldCheckGasFormula {
+			if st.l1Fee == nil {
+				st.l1Fee = new(uint256.Int)
+			}
+			if err := st.checkGasFormula(); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -732,6 +732,11 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	// Note optimismConfig will not be nil if rules.IsOptimismBedrock is true
 	if optimismConfig := st.evm.ChainConfig().Optimism; optimismConfig != nil && rules.IsOptimismBedrock && !st.msg.IsDepositTx {
 		gasCost := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee)
+
+		if st.evm.ChainConfig().IsCancun(st.evm.Context.BlockNumber, st.evm.Context.Time) {
+			gasCost.Add(gasCost, new(big.Int).Mul(new(big.Int).SetUint64(st.blobGasUsed()), st.evm.Context.BlobBaseFee))
+		}
+
 		amtU256, overflow := uint256.FromBig(gasCost)
 		if overflow {
 			return nil, fmt.Errorf("optimism gas cost overflows U256: %d", gasCost)


### PR DESCRIPTION
This PR adds a partial SGT feature mentioned [here](https://github.com/ethstorage/op-geth/issues/15) so that gas fee is first charged from SGT balance, if not enough, then native balance.

The formula here is:

```
tx.gasLimit * tx.gasPrice = tx.gasRemaining * tx.gasPrice(refund) + tx.gasUsed * effectiveTip(tip) + tx.gasUsed * baseFee(base fee) + l1Cost(l1 fee)
```