### PR TITLE
fix *uint256 reuse issue

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -297,7 +297,7 @@ func GetEffectiveGasBalance(state vm.StateDB, chainconfig *params.ChainConfig, a
 }
 
 func GetGasBalances(state vm.StateDB, chainconfig *params.ChainConfig, account common.Address) (*uint256.Int, *uint256.Int) {
-	balance := state.GetBalance(account)
+	balance := state.GetBalance(account).Clone()
 	if chainconfig != nil && chainconfig.IsOptimism() && chainconfig.Optimism.UseSoulGasToken {
 		sgtBalanceSlot := TargetSGTBalanceSlot(account)
 		sgtBalanceValue := state.GetState(types.SoulGasTokenAddr, sgtBalanceSlot)


### PR DESCRIPTION
This fixes a weird issue that was found in fault proof.

The key problem is that the returned `balance` is a pointer that can be modified by callers.  In most cases, the `balance` is not reused.  However, in some cases that `balances` is zero, statedb returns a cached zero uint256 (see https://github.com/ethstorage/op-geth/blob/e40be9201de97dfe6906229c0f827bf9ec0facfe/core/state/statedb.go#L330).  If the cache zero uint256 is modified, geth will result in some unexpected behavior such as account overflow issue.

# Test:
## Before
1, fault proof will fail after verifying a SGT tx 
2, dump the state, and find an account `0xfffffffffffffffffffffffffffffffffffffffe` has a negative balance.

## After
1, pass fault proof via `make verify-devnet`
2, `0xfffffffffffffffffffffffffffffffffffffffe` has zero balance 