### PR TITLE
`commitBlobTransaction`: fix nil pointer

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -396,7 +396,7 @@ func (miner *Miner) commitBlobTransaction(env *environment, tx *types.Transactio
 	// isn't really a better place right now. The blob gas limit is checked at block validation time
 	// and not during execution. This means core.ApplyTransaction will not return an error if the
 	// tx has too many blobs. So we have to explicitly check it here.
-	if (env.blobs+len(sc.Blobs))*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
+	if (env.blobs+len(tx.BlobHashes()))*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
 		return errors.New("max data blobs reached")
 	}
 	receipt, err := miner.applyTransaction(env, tx)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -389,14 +389,24 @@ func (miner *Miner) commitTransaction(env *environment, tx *types.Transaction) e
 
 func (miner *Miner) commitBlobTransaction(env *environment, tx *types.Transaction) error {
 	sc := tx.BlobTxSidecar()
-	if sc == nil && env.isEffectivelySequencing() /* we want to allow blob tx without blobs when it's deriving */ {
-		panic("blob transaction without blobs in miner")
+	var nblobs int
+	if sc == nil {
+		if env.isEffectivelySequencing() /* we want to allow blob tx without blobs when it's deriving */ {
+			panic("blob transaction without blobs in sequencing")
+		} else { // deriving, which does not have the sidecar
+			nblobs = len(tx.BlobHashes())
+		}
+	} else {
+		if !env.isEffectivelySequencing() {
+			panic("blob transaction with blobs in derivation")
+		}
+		nblobs = len(sc.Blobs)
 	}
 	// Checking against blob gas limit: It's kind of ugly to perform this check here, but there
 	// isn't really a better place right now. The blob gas limit is checked at block validation time
 	// and not during execution. This means core.ApplyTransaction will not return an error if the
 	// tx has too many blobs. So we have to explicitly check it here.
-	if (env.blobs+len(tx.BlobHashes() /* we changed here, otherwise it'll panic when deriving */))*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
+	if (env.blobs+nblobs)*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
 		return errors.New("max data blobs reached")
 	}
 	receipt, err := miner.applyTransaction(env, tx)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -396,7 +396,7 @@ func (miner *Miner) commitBlobTransaction(env *environment, tx *types.Transactio
 	// isn't really a better place right now. The blob gas limit is checked at block validation time
 	// and not during execution. This means core.ApplyTransaction will not return an error if the
 	// tx has too many blobs. So we have to explicitly check it here.
-	if (env.blobs+len(tx.BlobHashes()))*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
+	if (env.blobs+len(tx.BlobHashes() /* we changed here, otherwise it'll panic when deriving */))*params.BlobTxBlobGasPerBlob > params.MaxBlobGasPerBlock {
 		return errors.New("max data blobs reached")
 	}
 	receipt, err := miner.applyTransaction(env, tx)


### PR DESCRIPTION
Fix this panic found by @iteyelmp :


```
ERROR[12-26|08:19:43.819] RPC method engine_forkchoiceUpdatedV3 crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 4461 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
        github.com/ethereum/go-ethereum/rpc/service.go:199 +0x85
panic({0x18a3440?, 0x351a4f0?})
        runtime/panic.go:770 +0x132
github.com/ethereum/go-ethereum/miner.(*Miner).commitBlobTransaction(0xc00184c330?, 0xc0017fe930?, 0x786025?)
        github.com/ethereum/go-ethereum/miner/worker.go:399 +0x4d
github.com/ethereum/go-ethereum/miner.(*Miner).commitTransaction(0xc000504280, 0xc0006ea6c0, 0xc00183c120)
        github.com/ethereum/go-ethereum/miner/worker.go:364 +0x30d
github.com/ethereum/go-ethereum/miner.(*Miner).generateWork(0xc000504280, 0xc0017febf0, 0x5e?)
        github.com/ethereum/go-ethereum/miner/worker.go:157 +0x2a9
github.com/ethereum/go-ethereum/miner.(*Miner).buildPayload(0xc000504280, 0xc0017ff1e0, 0xfa?)
        github.com/ethereum/go-ethereum/miner/payload_building.go:311 +0x153
github.com/ethereum/go-ethereum/miner.(*Miner).BuildPayload(...)
        github.com/ethereum/go-ethereum/miner/miner.go:187
github.com/ethereum/go-ethereum/eth/catalyst.(*ConsensusAPI).forkchoiceUpdated(0xc000cb4960, {{0x58, 0x41, 0xfc, 0x2d, 0x60, 0xf9, 0x99, 0xd2, 0x12, ...}, ...}, ...)
        github.com/ethereum/go-ethereum/eth/catalyst/api.go:483 +0x2e45
github.com/ethereum/go-ethereum/eth/catalyst.(*ConsensusAPI).ForkchoiceUpdatedV3(0xc000cb4960?, {{0x58, 0x41, 0xfc, 0x2d, 0x60, 0xf9, 0x99, 0xd2, 0x12, ...}, ...}, ...)
        github.com/ethereum/go-ethereum/eth/catalyst/api.go:251 +0x3fa
reflect.Value.call({0xc000dc10e0?, 0xc0001bd510?, 0x60?}, {0x1b246a6, 0x4}, {0xc00183c060, 0x3, 0xc00183c060?})
        reflect/value.go:596 +0xca6
reflect.Value.Call({0xc000dc10e0?, 0xc0001bd510?, 0x2?}, {0xc00183c060?, 0x16?, 0x16?})
        reflect/value.go:380 +0xb9
github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc0005db5c0, {0x28b8978, 0xc0006a7180}, {0xc0017ee5a0, 0x1a}, {0xc00164b7d0, 0x2, 0x4e14af?})
        github.com/ethereum/go-ethereum/rpc/service.go:205 +0x36d
github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc00165f500?, {0x28b8978?, 0xc0006a7180?}, 0xc000176700, 0x2?, {0xc00164b7d0?, 0xc001907dc0?, 0x41e6b8?})
        github.com/ethereum/go-ethereum/rpc/handler.go:568 +0x3c
github.com/ethereum/go-ethereum/rpc.(*handler).handleCall(0xc0006ad040, 0xc00164b710, 0xc000176700)
        github.com/ethereum/go-ethereum/rpc/handler.go:515 +0x22f
github.com/ethereum/go-ethereum/rpc.(*handler).handleCallMsg(0xc0006ad040, 0xc00164b710, 0xc000176700)
        github.com/ethereum/go-ethereum/rpc/handler.go:473 +0x22d
github.com/ethereum/go-ethereum/rpc.(*handler).handleNonBatchCall(0xc0006ad040, 0xc00164b710, 0xc000176700)
        github.com/ethereum/go-ethereum/rpc/handler.go:299 +0x18a
github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1.1(0x28b8978?)
        github.com/ethereum/go-ethereum/rpc/handler.go:272 +0x25
github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc.func1()
        github.com/ethereum/go-ethereum/rpc/handler.go:390 +0xbe
created by github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc in goroutine 31
        github.com/ethereum/go-ethereum/rpc/handler.go:386 +0x79
```