### PR TITLE
add default port for httpsgt

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -272,7 +272,7 @@ func (c *Config) HTTPEndpoint() string {
 
 // DefaultHTTPEndpoint returns the HTTP endpoint used by default.
 func DefaultHTTPEndpoint() string {
-	config := &Config{HTTPHost: DefaultHTTPHost, HTTPPort: DefaultHTTPPort, AuthPort: DefaultAuthPort}
+	config := &Config{HTTPHost: DefaultHTTPHost, HTTPPort: DefaultHTTPPort, HTTPSGTPort: DefaultHTTPSGTPort, AuthPort: DefaultAuthPort}
 	return config.HTTPEndpoint()
 }
 

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -59,6 +59,7 @@ var (
 var DefaultConfig = Config{
 	DataDir:              DefaultDataDir(),
 	HTTPPort:             DefaultHTTPPort,
+	HTTPSGTPort:          DefaultHTTPSGTPort,
 	AuthAddr:             DefaultAuthHost,
 	AuthPort:             DefaultAuthPort,
 	AuthVirtualHosts:     DefaultAuthVhosts,


### PR DESCRIPTION
This PR makes `8645` the port for httpsgt if `httpsgt.port` is not specified.