### PR TITLE
add publish-op-geth.yml

### DIFF
--- a/.github/workflows/publish-op-geth.yml
+++ b/.github/workflows/publish-op-geth.yml
@@ -1,0 +1,65 @@
+# This workflow will publish a github release for op-geth
+
+name: Publish
+run-name: ${{ github.actor }} is publishing an op-geth release 🚀
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Always wait for previous release to finish before releasing again
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        arch: [amd64, arm64]
+        exclude:
+          - os: ubuntu-latest
+            arch: arm64
+    env:
+      BUILD_DIR: op-geth.${{ github.ref_name }}
+      BIN_DIR: op-geth.${{ github.ref_name }}/build/bin
+      FILE_NAME: op-geth.${{ github.ref_name }}.${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}-${{ matrix.arch }}.tar.gz
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.7'
+
+      - name: Build
+        run: |
+          TARGETOS=${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }} TARGETARCH=${{ matrix.arch }} make geth
+          mkdir -p ${{ env.BIN_DIR }}
+          mv build/bin/geth ${{ env.BIN_DIR }}/
+          tar -czvf ${{ env.FILE_NAME }} ${{ env.BUILD_DIR }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.FILE_NAME }}
+          path: ${{ env.FILE_NAME }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref }}
+          name: Release ${{ github.ref_name }}
+          files: |
+            **/*
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.github/workflows/publish-op-geth.yml
+++ b/.github/workflows/publish-op-geth.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build
         run: |
-          TARGETOS=${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }} TARGETARCH=${{ matrix.arch }} make geth
+          CGO_ENABLED=0 TARGETOS=${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }} TARGETARCH=${{ matrix.arch }} make geth
           mkdir -p ${{ env.BIN_DIR }}
           mv build/bin/geth ${{ env.BIN_DIR }}/
           tar -czvf ${{ env.FILE_NAME }} ${{ env.BUILD_DIR }}


### PR DESCRIPTION
This PR provides a binary release workflow for op-geth.

To trigger a binary release of op-node, just push of tag of the format `v*`.

An example of the release is [here](https://github.com/blockchaindevsh/op-geth/releases/tag/v1.0).